### PR TITLE
Add support for sending SNS notifications during batch processing

### DIFF
--- a/config_item.json
+++ b/config_item.json
@@ -19,6 +19,8 @@
   "manifestBucket": {"S": "${manifest_bucket}"},
   "manifestKey": {"S": "${manifest_prefix}"},
   "failedManifestKey": {"S": "${failed_manifest_prefix}"},
+  "successTopicARN": {"S": "${success_topic_arn}"},
+  "failureTopicARN": {"S": "${failure_topic_arn}"},
   "batchSize": {"N": "1"},
   "currentBatch": {"S": "${current_batch}" }
 }

--- a/config_table.tf
+++ b/config_table.tf
@@ -50,6 +50,8 @@ data "template_file" "loader_config_full_item" {
     manifest_bucket = aws_s3_bucket.manifest.bucket
     manifest_prefix = var.manifest_prefix
     failed_manifest_prefix = var.failed_manifest_prefix
+    success_topic_arn = aws_sns_topic.success_sns_topic.arn
+    failure_topic_arn = aws_sns_topic.failure_sns_topic.arn
     current_batch = random_id.current_batch.b64_url
     column_list = data.http.column_list[each.key].body
     truncate_target = true
@@ -94,6 +96,8 @@ data "template_file" "loader_config_incremental_item" {
     manifest_bucket = aws_s3_bucket.manifest.bucket
     manifest_prefix = var.manifest_prefix
     failed_manifest_prefix = var.failed_manifest_prefix
+    success_topic_arn = aws_sns_topic.success_sns_topic.arn
+    failure_topic_arn = aws_sns_topic.failure_sns_topic.arn
     current_batch = random_id.current_batch.b64_url
     column_list = data.http.column_list[each.key].body
     truncate_target = false

--- a/loader.tf
+++ b/loader.tf
@@ -39,15 +39,15 @@ resource "aws_s3_bucket_notification" "notifications" {
 
 resource "aws_sns_topic" "success_sns_topic" {
   name = var.success_topic_name
-  policy = data.aws_iam_policy_document.success_sns_notification_policy.json
+  policy = data.aws_iam_policy_document.sns_notification_policy.json
 }
 
 resource "aws_sns_topic" "failure_sns_topic" {
   name = var.failure_topic_name
-  policy = data.aws_iam_policy_document.failure_sns_notification_policy.json
+  policy = data.aws_iam_policy_document.sns_notification_policy.json
 }
 
-data "aws_iam_policy_document" "success_sns_notification_policy" {
+data "aws_iam_policy_document" "sns_notification_policy" {
   statement {
     effect = "Allow"
     principals {
@@ -59,28 +59,6 @@ data "aws_iam_policy_document" "success_sns_notification_policy" {
     ]
     resources = [
       "arn:aws:sns:*:*:${var.success_topic_name}",
-    ]
-    condition {
-      test      = "ArnLike"
-      variable  = "aws:SourceArn"
-      values    = [
-        aws_lambda_function.loader.arn,
-      ]
-    }
-  }
-}
-
-data "aws_iam_policy_document" "failure_sns_notification_policy" {
-  statement {
-    effect = "Allow"
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-    actions = [
-      "SNS:Publish",
-    ]
-    resources = [
       "arn:aws:sns:*:*:${var.failure_topic_name}",
     ]
     condition {

--- a/loader.tf
+++ b/loader.tf
@@ -36,3 +36,41 @@ resource "aws_s3_bucket_notification" "notifications" {
     filter_prefix       = "full"
   }
 }
+
+resource "aws_sns_topic" "success_sns_topic" {
+  name = var.success_topic_name
+
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[{
+        "Effect": "Allow",
+        "Principal": {"AWS":"*"},
+        "Action": "SNS:Publish",
+        "Resource": "arn:aws:sns:*:*:${var.success_topic_name}",
+        "Condition":{
+            "ArnLike":{"aws:SourceArn":"${aws_lambda_function.loader.arn}"}
+        }
+    }]
+}
+POLICY
+}
+
+resource "aws_sns_topic" "failure_sns_topic" {
+  name = var.failure_topic_name
+
+  policy = <<POLICY
+{
+    "Version":"2012-10-17",
+    "Statement":[{
+        "Effect": "Allow",
+        "Principal": {"AWS":"*"},
+        "Action": "SNS:Publish",
+        "Resource": "arn:aws:sns:*:*:${var.failure_topic_name}",
+        "Condition":{
+            "ArnLike":{"aws:SourceArn":"${aws_lambda_function.loader.arn}"}
+        }
+    }]
+}
+POLICY
+}

--- a/loader.tf
+++ b/loader.tf
@@ -39,38 +39,56 @@ resource "aws_s3_bucket_notification" "notifications" {
 
 resource "aws_sns_topic" "success_sns_topic" {
   name = var.success_topic_name
-
-  policy = <<POLICY
-{
-    "Version":"2012-10-17",
-    "Statement":[{
-        "Effect": "Allow",
-        "Principal": {"AWS":"*"},
-        "Action": "SNS:Publish",
-        "Resource": "arn:aws:sns:*:*:${var.success_topic_name}",
-        "Condition":{
-            "ArnLike":{"aws:SourceArn":"${aws_lambda_function.loader.arn}"}
-        }
-    }]
-}
-POLICY
+  policy = data.aws_iam_policy_document.success_sns_notification_policy.json
 }
 
 resource "aws_sns_topic" "failure_sns_topic" {
   name = var.failure_topic_name
-
-  policy = <<POLICY
-{
-    "Version":"2012-10-17",
-    "Statement":[{
-        "Effect": "Allow",
-        "Principal": {"AWS":"*"},
-        "Action": "SNS:Publish",
-        "Resource": "arn:aws:sns:*:*:${var.failure_topic_name}",
-        "Condition":{
-            "ArnLike":{"aws:SourceArn":"${aws_lambda_function.loader.arn}"}
-        }
-    }]
+  policy = data.aws_iam_policy_document.failure_sns_notification_policy.json
 }
-POLICY
+
+data "aws_iam_policy_document" "success_sns_notification_policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "SNS:Publish",
+    ]
+    resources = [
+      "arn:aws:sns:*:*:${var.success_topic_name}",
+    ]
+    condition {
+      test      = "ArnLike"
+      variable  = "aws:SourceArn"
+      values    = [
+        aws_lambda_function.loader.arn,
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "failure_sns_notification_policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "SNS:Publish",
+    ]
+    resources = [
+      "arn:aws:sns:*:*:${var.failure_topic_name}",
+    ]
+    condition {
+      test      = "ArnLike"
+      variable  = "aws:SourceArn"
+      values    = [
+        aws_lambda_function.loader.arn,
+      ]
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,16 @@ variable "failed_manifest_prefix" {
   type        = string
   description = "A file prefix that will be used for manifest logs on failure"
 }
+variable "success_topic_name" {
+  default = "ControlshiftLambdaLoaderSuccess"
+  type        = string
+  description = "An SNS topic name that will be notified about batch processing successes"
+}
+variable "failure_topic_name" {
+  default = "ControlshiftLambdaLoaderFailure"
+  type        = string
+  description = "An SNS topic name that will be notified about batch processing failures"
+}
 
 variable "controlshift_hostname" {
   default = "staging.controlshiftlabs.com"


### PR DESCRIPTION
Adds support for sending SNS notifications for batch processing successes and failures. The SNS topics will be created by Terraform, after which subscriptions (e.g., email addresses) can be added to each topic via the SNS console in AWS to specify where the notifications should be delivered.

The awslabs/aws-lambda-redshift-loader repository contains a Lambda function that can be used to automatically reprocess failed batches by subscribing the Lambda to the failure SNS topic, but I haven't tested that yet.