### PR TITLE
Add a variable to allow setting the timeout on the receiver Lambda

### DIFF
--- a/receiver.tf
+++ b/receiver.tf
@@ -10,6 +10,7 @@ resource "aws_lambda_function" "receiver_lambda" {
   role          = aws_iam_role.receiver_lambda_role.arn
   handler       = "receiver.handler"
   runtime       = "nodejs10.x"
+  timeout       = var.receiver_timeout
   source_code_hash = filebase64sha256(data.archive_file.receiver_zip.output_path)
 
   environment {

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,9 @@ variable "controlshift_hostname" {
   type        = string
   description = "The hostname of your ControlShift instance. Likely to be something like action.myorganization.org"
 }
+
+variable "receiver_timeout" {
+  default = 60
+  type        = number
+  description = "The timeout for the receiving Lambda, in seconds"
+}


### PR DESCRIPTION
Adding a variable to allow setting the timeout on the receiver Lambda, because the default of 3 seconds is not enough to retrieve large tables (the `signatures` table in particular).