### PR TITLE
Truncate strings that are too large to fit

### DIFF
--- a/config_item.json
+++ b/config_item.json
@@ -12,7 +12,7 @@
       "truncateTarget": {"BOOL": ${truncate_target}},
       "useSSL": {"BOOL": false}
     }}]},
-  "copyOptions": {"S": "EMPTYASNULL"},
+  "copyOptions": {"S": "EMPTYASNULL TRUNCATECOLUMNS"},
   "dataFormat": {"S": "CSV"},
   "csvDelimiter": {"S": ","},
   "ignoreCsvHeader": {"BOOL": true},


### PR DESCRIPTION
Redshift has a max length on all VARCHAR fields; there is no string field with unlimited length.  Truncate incoming rows with e.g. petition bodies that are too long rather than failing with an error.