### PR TITLE
use schema for redshift glue connection

### DIFF
--- a/glue_job.tf
+++ b/glue_job.tf
@@ -35,6 +35,7 @@ data "template_file" "signatures_script" {
   vars = {
     catalog_database_name = aws_glue_catalog_database.catalog_db.name
     redshift_database_name = var.redshift_database_name
+    redshift_schema = var.redshift_schema
     redshift_connection_name = aws_glue_connection.redshift_connection.name
   }
 }

--- a/templates/signatures_job.py.tpl
+++ b/templates/signatures_job.py.tpl
@@ -109,7 +109,7 @@ datasink4 = glueContext.write_dynamic_frame.from_jdbc_conf(
     frame = resolvechoice2,
     catalog_connection = "${redshift_connection_name}",
     connection_options = {"preactions": "truncate table signatures;",
-                          "dbtable": "signatures",
+                          "dbtable": "${redshift_schema}.signatures",
                           "database": "${redshift_database_name}"},
     redshift_tmp_dir = args["TempDir"], transformation_ctx = "datasink4")
 


### PR DESCRIPTION
Change glue configuration to point at the schema specified in the terraform plan.