### PR TITLE
Keep loader lambda policy from being overwritten across regions

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -71,7 +71,7 @@ resource "aws_iam_role" "loader_lambda_role" {
 }
 
 resource "aws_iam_role_policy" "lambda_loads_tables" {
-  name = "AllowsLoaderExecution"
+  name_prefix = "AllowsLoaderExecution"
   role = aws_iam_role.loader_lambda_role.id
   policy = data.aws_iam_policy_document.loader_execution_policy.json
 }


### PR DESCRIPTION
Different regions each need their own loader lambda role, since the role needs access to region-specific resources.  Just renaming the role is not enough, however, the role policy would still be overwritten so switch to name_prefix.