### PR TITLE
compact() subnet_ids and security_group_ids

### DIFF
--- a/loader.tf
+++ b/loader.tf
@@ -8,8 +8,8 @@ resource "aws_lambda_function" "loader" {
   timeout       = 900
 
   vpc_config {
-    subnet_ids         = concat(var.lambda_loader_subnet_ids, list(""))
-    security_group_ids = concat(var.lambda_loader_security_group_ids, list(""))
+    subnet_ids         = compact(concat(var.lambda_loader_subnet_ids, list("")))
+    security_group_ids = compact(concat(var.lambda_loader_security_group_ids, list("")))
   }
 
   environment {


### PR DESCRIPTION
I'm seeing a minor bug here. `concat()` will return include an extra empty string in the list, which shows `terraform plan` shows as a resource change. `compact()` can clean that up.

Ref: https://www.terraform.io/docs/language/functions/compact.html