### PR TITLE
Update syntax to work with modern Terraform

### DIFF
--- a/loader.tf
+++ b/loader.tf
@@ -8,8 +8,8 @@ resource "aws_lambda_function" "loader" {
   timeout       = 900
 
   vpc_config {
-    subnet_ids         = compact(concat(var.lambda_loader_subnet_ids, list("")))
-    security_group_ids = compact(concat(var.lambda_loader_security_group_ids, list("")))
+    subnet_ids         = var.lambda_loader_subnet_ids
+    security_group_ids = var.lambda_loader_security_group_ids
   }
 
   environment {

--- a/providers.tf
+++ b/providers.tf
@@ -1,4 +1,0 @@
-provider "archive" { }
-provider "template" { }
-provider "random" { }
-provider "http" { }

--- a/s3.tf
+++ b/s3.tf
@@ -1,6 +1,5 @@
 # Additional provider configuration for region your controlshift platform lives within.
 provider "aws" {
-  version = "~> 2.0"
   alias  = "controlshift"
   region = var.controlshift_aws_region
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    archive = {
+      source = "hashicorp/archive"
+    }
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 2.0"
+    }
+    http = {
+      source = "hashicorp/http"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 0.13"
   required_providers {
     archive = {
       source = "hashicorp/archive"


### PR DESCRIPTION
This makes several tweaks to the Terraform config syntax so it is compatible with newer versions of Terraform.

I _think_ it should now work with 0.13 or greater, as specified in the new terraform version requirement. I tested with version 1.0.3.