### PR TITLE
Ensure sqs.sendMessage completes

### DIFF
--- a/lambdas/receiver.js
+++ b/lambdas/receiver.js
@@ -8,7 +8,7 @@ AWS.config.update({region: process.env.AWS_REGION});
 // Create an SQS service object
 const sqs = new AWS.SQS();
 
-function enqueueTask(receivedData, kind) {
+async function enqueueTask(receivedData, kind) {
   console.log("Processing: " + receivedData.url);
 
   let messageBody = {};
@@ -38,9 +38,9 @@ function enqueueTask(receivedData, kind) {
   let loaderResp = sqs.sendMessage(loaderQueueParams).promise();
   let glueResp = sqs.sendMessage(glueQueueParams).promise();
 
-  Promise.all([loaderResp, glueResp]).then(
+  await Promise.all([loaderResp, glueResp]).then(
     function(data) {
-      console.log("Success " + data.MessageId);
+      console.log("Success " + JSON.stringify(data));
     },
     function(error) {
       console.log("Error", error);

--- a/loader.tf
+++ b/loader.tf
@@ -8,8 +8,8 @@ resource "aws_lambda_function" "loader" {
   timeout       = 900
 
   vpc_config {
-    subnet_ids         = concat(var.lambda_loader_subnet_ids, list(""))
-    security_group_ids = concat(var.lambda_loader_security_group_ids, list(""))
+    subnet_ids         = compact(concat(var.lambda_loader_subnet_ids, list("")))
+    security_group_ids = compact(concat(var.lambda_loader_security_group_ids, list("")))
   }
 
   environment {


### PR DESCRIPTION
The receiver lambda function may sometimes terminate before the Promise completes. This can cause messages to never reach the SQS queue, and the related lambda function(s) will not fire. Adding an `await` will ensure that the messages are fully received by SQS.