### PR TITLE
Fixes for setting up Glue jobs

### DIFF
--- a/glue_job.tf
+++ b/glue_job.tf
@@ -123,13 +123,10 @@ resource "aws_glue_connection" "redshift_connection" {
     JDBC_ENFORCE_SSL    = false
   }
 
-  dynamic "physical_connection_requirements" {
-    for_each = var.glue_physical_connection_requirements == null ? [] : list(var.glue_physical_connection_requirements)
-    content {
-      availability_zone = physical_connection_requirements.value.availability_zone
-      security_group_id_list = physical_connection_requirements.value.security_group_id_list
-      subnet_id = physical_connection_requirements.value.subnet_id
-    }
+  physical_connection_requirements {
+    availability_zone = var.glue_physical_connection_requirements.availability_zone
+    security_group_id_list = var.glue_physical_connection_requirements.security_group_id_list
+    subnet_id = var.glue_physical_connection_requirements.subnet_id
   }
 }
 

--- a/glue_job.tf
+++ b/glue_job.tf
@@ -246,3 +246,14 @@ resource "aws_cloudwatch_event_target" "notify_failed_glue_job" {
   target_id = "notify-failed-glue-job-run"
   arn       = aws_sns_topic.glue_job_failure.arn
 }
+
+
+data "aws_vpc" "main" {
+  id = var.vpc_id
+}
+
+# Glue jobs require a VPC endpoint for connecting to S3
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id       = data.aws_vpc.main.id
+  service_name = "com.amazonaws.${var.aws_region}.s3"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -109,5 +109,4 @@ variable "lambda_loader_security_group_ids" {
 variable "glue_physical_connection_requirements" {
   type = object({ availability_zone=string, subnet_id=string, security_group_id_list=list(string) })
   description = "A terraform map of the physical_connection_requirements property of the glue redshift connection. See Terraform aws_glue_connection docs."
-  default = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -110,3 +110,8 @@ variable "glue_physical_connection_requirements" {
   type = object({ availability_zone=string, subnet_id=string, security_group_id_list=list(string) })
   description = "A terraform map of the physical_connection_requirements property of the glue redshift connection. See Terraform aws_glue_connection docs."
 }
+
+variable "vpc_id" {
+  type = string
+  description = "The ID of the VPC Glue uses for connecting with Redshift"
+}


### PR DESCRIPTION
Without the [`physical_connection_requirements`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_connection#physical_connection_requirements) settings, the Redshift connection is invalid and Glue jobs cannot connect. This PR makes this a required variable.

Glue jobs also require a VPC endpoint to S3 to exist, so we create a new one. I experimented a bit trying to find a way to only create if there isn't already one set up for the VPC, or to throw an error if there isn't an endpoint already set; but it's pretty tricky to do with terraform and all the examples I found involved some kind of hack. According to [AWS docs](https://aws.amazon.com/vpc/pricing/):

> There are no data processing or hourly charges for using Gateway Type VPC endpoints.

so creating an extra endpoint shouldn't be a problem.