### PR TITLE
VPC endpoint must be associated with the subnet's route table

### DIFF
--- a/glue_job.tf
+++ b/glue_job.tf
@@ -252,8 +252,19 @@ data "aws_vpc" "main" {
   id = var.vpc_id
 }
 
+data "aws_route_tables" "all_route_tables" {
+  vpc_id = data.aws_vpc.main.id
+}
+
 # Glue jobs require a VPC endpoint for connecting to S3
 resource "aws_vpc_endpoint" "s3" {
   vpc_id       = data.aws_vpc.main.id
   service_name = "com.amazonaws.${var.aws_region}.s3"
+}
+
+resource "aws_vpc_endpoint_route_table_association" "s3" {
+  count = length(data.aws_route_tables.all_route_tables.ids)
+
+  route_table_id  = tolist(data.aws_route_tables.all_route_tables.ids)[count.index]
+  vpc_endpoint_id = aws_vpc_endpoint.s3.id
 }


### PR DESCRIPTION
:canned_food: AWS API allows the VPC Endpoint to be created without any associated route table, but this leaves it unusable.