### PR TITLE
Upgraded to Glue 3.0 runtime for job

### DIFF
--- a/glue_job.tf
+++ b/glue_job.tf
@@ -133,7 +133,7 @@ resource "aws_glue_connection" "redshift_connection" {
 resource "aws_glue_job" "signatures_full" {
   name = "cs-${var.controlshift_environment}-signatures-full"
   connections = [ aws_glue_connection.redshift_connection.name ]
-  glue_version = "1.0"
+  glue_version = "3.0"
   default_arguments = {
     "--TempDir": "s3://${aws_s3_bucket.glue_resources.bucket}/${var.controlshift_environment}/temp",
     "--job-bookmark-option": "job-bookmark-disable",


### PR DESCRIPTION
🥫 I checked the migration instructions from https://docs.aws.amazon.com/glue/latest/dg/migrating-version-30.html#migrating-version-30-from-10 and confirmed no changes are required. I've also manually updated the version we run in our AWS test account and verified the job runs correctly (and much faster!)