### PR TITLE
Add 'compress' setting to redshift loader lambda configuration based on response from CSL

### DIFF
--- a/config_item.json
+++ b/config_item.json
@@ -22,5 +22,6 @@
   "successTopicARN": {"S": "${success_topic_arn}"},
   "failureTopicARN": {"S": "${failure_topic_arn}"},
   "batchSize": {"N": "1"},
-  "currentBatch": {"S": "${current_batch}" }
+  "currentBatch": {"S": "${current_batch}"},
+  "compress": {"S": "${compress}"}
 }


### PR DESCRIPTION
This adds the `compress` property with the value from `compression_format` on response from schema API call to CSL.
The controlshift-redshift-loader Lambda uses this setting to include on `COPY` command to Redshift with the compression format if required.