### PR TITLE
Allow multiple syncs per AWS account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 lambdas/*.zip
 .idea/
 .DS_Store
+
+# vim files
+*.swp

--- a/api_gateway.tf
+++ b/api_gateway.tf
@@ -1,4 +1,5 @@
 // Provides a settings of an API Gateway Account. Settings is applied region-wide per provider block.
 resource "aws_api_gateway_account" "settings" {
+  count = var.manage_aws_api_gateway_account_settings
   cloudwatch_role_arn = aws_iam_role.api_gateway_role.arn
 }

--- a/batches_table.tf
+++ b/batches_table.tf
@@ -1,5 +1,5 @@
 resource "aws_dynamodb_table" "batches" {
-  name  = "LambdaRedshiftBatches"
+  name  = "LambdaRedshiftBatches${local.namespace_suffix_dashed}"
   billing_mode = "PROVISIONED"
   read_capacity  = 1
   write_capacity = 5

--- a/config_table.tf
+++ b/config_table.tf
@@ -1,5 +1,5 @@
 resource "aws_dynamodb_table" "loader_config" {
-  name  = "LambdaRedshiftBatchLoadConfig"
+  name  = "LambdaRedshiftBatchLoadConfig${local.namespace_suffix_dashed}"
   billing_mode = "PROVISIONED"
   read_capacity  = 1
   write_capacity = 5
@@ -120,7 +120,7 @@ resource "aws_kms_ciphertext" "redshift_password" {
 }
 
 resource "aws_kms_alias" "lambda_alias" {
-  name = "alias/LambaRedshiftLoaderKey"
+  name = "alias/LambaRedshiftLoaderKey${local.namespace_suffix_dashed}"
   target_key_id = aws_kms_key.lambda_config.key_id
 }
 

--- a/glue_job.tf
+++ b/glue_job.tf
@@ -139,6 +139,8 @@ resource "aws_glue_job" "signatures_full" {
     "--job-bookmark-option": "job-bookmark-disable",
     "--job-language": "python"
   }
+  number_of_workers = 10
+  worker_type = "G.1X"
 
   role_arn = aws_iam_role.glue_service_role.arn
 

--- a/glue_job.tf
+++ b/glue_job.tf
@@ -264,8 +264,8 @@ resource "aws_vpc_endpoint" "s3" {
 }
 
 resource "aws_vpc_endpoint_route_table_association" "s3" {
-  count = length(data.aws_route_tables.all_route_tables.ids)
+  count = min(length(data.aws_route_tables.all_route_tables.ids), var.manage_aws_vpc_endpoint_s3)
 
   route_table_id  = tolist(data.aws_route_tables.all_route_tables.ids)[count.index]
-  vpc_endpoint_id = aws_vpc_endpoint.s3.id
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
 }

--- a/glue_job.tf
+++ b/glue_job.tf
@@ -139,8 +139,6 @@ resource "aws_glue_job" "signatures_full" {
     "--job-bookmark-option": "job-bookmark-disable",
     "--job-language": "python"
   }
-  number_of_workers = 10
-  worker_type = "G.1X"
 
   role_arn = aws_iam_role.glue_service_role.arn
 

--- a/glue_job.tf
+++ b/glue_job.tf
@@ -258,6 +258,7 @@ data "aws_route_tables" "all_route_tables" {
 
 # Glue jobs require a VPC endpoint for connecting to S3
 resource "aws_vpc_endpoint" "s3" {
+  count = var.manage_aws_vpc_endpoint_s3
   vpc_id       = data.aws_vpc.main.id
   service_name = "com.amazonaws.${var.aws_region}.s3"
 }

--- a/iam.tf
+++ b/iam.tf
@@ -10,8 +10,8 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 }
 
 resource "aws_iam_role" "receiver_lambda_role" {
-  name = "ReceiverLambdaRole"
-  description = "Used by the controlshift-webhook-handler Lambda for receiving db replication data from ControlShift"
+  name = "ReceiverLambdaRole${local.namespace_suffix_dashed}"
+  description = "Used by the controlshift-webhook-handler${local.namespace_suffix_dashed} Lambda for receiving db replication data from ControlShift"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }
 
@@ -37,13 +37,13 @@ data "aws_iam_policy_document" "receiver_execution_policy" {
 }
 
 resource "aws_iam_role_policy" "lambda_receiver" {
-  name = "AllowsReceiverExecution"
+  name = "AllowsReceiverExecution${local.namespace_suffix_dashed}"
   role = aws_iam_role.receiver_lambda_role.id
   policy = data.aws_iam_policy_document.receiver_execution_policy.json
 }
 
 resource "aws_iam_role" "api_gateway_role" {
-  name = "APIGatewayRole"
+  name = "APIGatewayRole${local.namespace_suffix_dashed}"
   description = "Used by the Controlshift API Gateway webhook endpoint for CloudWatch logging"
   assume_role_policy = data.aws_iam_policy_document.gateway_assume_role.json
 }
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy_attachment" "gateway_cloudwatch_logging" {
 
 resource "aws_iam_role" "loader_lambda_role" {
   name_prefix = "LoaderLambdaRole"
-  description = "Used by the controlshift-redshift-loader Lambda for processing db replication data from ControlShift into Redshift"
+  description = "Used by the controlshift-redshift-loader${local.namespace_suffix_dashed} Lambda for processing db replication data from ControlShift into Redshift"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }
 
@@ -192,14 +192,14 @@ data "aws_iam_policy_document" "run_glue_job_execution_policy" {
 }
 
 resource "aws_iam_role_policy" "lambda_run_glue_job" {
-  name = "AllowsRunGlueJobExecution"
+  name = "AllowsRunGlueJobExecution${local.namespace_suffix_dashed}"
   role = aws_iam_role.run_glue_job_lambda_role.id
   policy = data.aws_iam_policy_document.run_glue_job_execution_policy.json
 }
 
 resource "aws_iam_role" "run_glue_job_lambda_role" {
-  name = "RunGlueJobLambdaRole"
-  description = "Used by the controlshift-run-glue-job Lambda for triggering AWS Glue job once the crawler finishes"
+  name = "RunGlueJobLambdaRole${local.namespace_suffix_dashed}"
+  description = "Used by the controlshift-run-glue-job${local.namespace_suffix_dashed} Lambda for triggering AWS Glue job once the crawler finishes"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }
 
@@ -231,13 +231,13 @@ data "aws_iam_policy_document" "run_glue_crawler_execution_policy" {
 }
 
 resource "aws_iam_role_policy" "lambda_run_glue_crawler" {
-  name = "AllowsRunGlueCrawlerExecution"
+  name = "AllowsRunGlueCrawlerExecution${local.namespace_suffix_dashed}"
   role = aws_iam_role.run_glue_crawler_lambda_role.id
   policy = data.aws_iam_policy_document.run_glue_crawler_execution_policy.json
 }
 
 resource "aws_iam_role" "run_glue_crawler_lambda_role" {
-  name = "RunGlueCrawlerLambdaRole"
-  description = "Used by the controlshift-run-glue-crawler Lambda for triggering AWS Glue crawler when a new signatures table full data export is available."
+  name = "RunGlueCrawlerLambdaRole${local.namespace_suffix_dashed}"
+  description = "Used by the controlshift-run-glue-crawler${local.namespace_suffix_dashed} Lambda for triggering AWS Glue crawler when a new signatures table full data export is available."
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }

--- a/loader.tf
+++ b/loader.tf
@@ -1,5 +1,6 @@
 resource "aws_lambda_function" "loader" {
   s3_bucket = local.lambda_buckets[var.aws_region]
+  # TODO: This needs to be updated
   s3_key = "LambdaRedshiftLoader/AWSLambdaRedshiftLoader-2.7.8.zip"
   function_name = "controlshift-redshift-loader"
   role          = aws_iam_role.loader_lambda_role.arn

--- a/loader.tf
+++ b/loader.tf
@@ -1,12 +1,7 @@
 resource "aws_lambda_function" "loader" {
-
-  # Need to customize the code to support custom table names
-  #s3_bucket = local.lambda_buckets[var.aws_region]
-  #s3_key = "LambdaRedshiftLoader/AWSLambdaRedshiftLoader-2.7.8.zip"
-  s3_bucket = "tmc-custom-controlshift-aws-lambda-redshift-loader"
-  s3_key = "LambdaRedshiftLoader/AWSLambdaRedshiftLoader-tmc-custom-20211101-2.7.8.zip"
-
-  function_name = "controlshift-redshift-loader${local.namespace_suffix_dashed}"
+  s3_bucket = local.lambda_buckets[var.aws_region]
+  s3_key = "LambdaRedshiftLoader/AWSLambdaRedshiftLoader-2.7.8.zip"
+  function_name = "controlshift-redshift-loader"
   role          = aws_iam_role.loader_lambda_role.arn
   handler       = "index.handler"
   runtime       = "nodejs12.x"

--- a/loader.tf
+++ b/loader.tf
@@ -1,7 +1,7 @@
 resource "aws_lambda_function" "loader" {
   s3_bucket = local.lambda_buckets[var.aws_region]
   s3_key = "LambdaRedshiftLoader/AWSLambdaRedshiftLoader-2.7.8.zip"
-  function_name = "controlshift-redshift-loader"
+  function_name = "controlshift-redshift-loader${local.namespace_suffix_dashed}"
   role          = aws_iam_role.loader_lambda_role.arn
   handler       = "index.handler"
   runtime       = "nodejs12.x"

--- a/loader.tf
+++ b/loader.tf
@@ -1,6 +1,11 @@
 resource "aws_lambda_function" "loader" {
-  s3_bucket = local.lambda_buckets[var.aws_region]
-  s3_key = "LambdaRedshiftLoader/AWSLambdaRedshiftLoader-2.7.8.zip"
+
+  # Need to customize the code to support custom table names
+  #s3_bucket = local.lambda_buckets[var.aws_region]
+  #s3_key = "LambdaRedshiftLoader/AWSLambdaRedshiftLoader-2.7.8.zip"
+  s3_bucket = "tmc-custom-controlshift-aws-lambda-redshift-loader"
+  s3_key = "LambdaRedshiftLoader/AWSLambdaRedshiftLoader-tmc-custom-20211101-2.7.8.zip"
+
   function_name = "controlshift-redshift-loader${local.namespace_suffix_dashed}"
   role          = aws_iam_role.loader_lambda_role.arn
   handler       = "index.handler"
@@ -16,6 +21,9 @@ resource "aws_lambda_function" "loader" {
     variables = {
       "DEBUG" = "true"
       "CONTROLSHIFT_AWS_REGION" = var.controlshift_aws_region
+      "OVERRIDE_CONFIG_TABLE" = "LambdaRedshiftBatchLoadConfig${local.namespace_suffix_dashed}"
+      "OVERRIDE_BATCH_TABLE" = "LambdaRedshiftBatches${local.namespace_suffix_dashed}"
+      "OVERRIDE_FILES_TABLE" = "LambdaRedshiftProcessedFiles${local.namespace_suffix_dashed}"
     }
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -5,4 +5,7 @@ locals {
     "us-east-1" = "changesprout-lambdas-us-east-1"
     "us-west-1" = "changesprout-lambdas-us-west-1"
   }
+  
+  namespace_suffix_dashed      = length(var.namespace_suffixes) == 0 ? "" : "-${join("-", var.namespace_suffixes)}"
+  namespace_suffix_underscored = length(var.namespace_suffixes) == 0 ? "" : "_${join("_", var.namespace_suffixes)}"
 }

--- a/logs.tf
+++ b/logs.tf
@@ -1,16 +1,16 @@
 resource "aws_cloudwatch_log_group" "loader" {
-  name = "/aws/lambda/controlshift-redshift-loader"
+  name = "/aws/lambda/controlshift-redshift-loader${local.namespace_suffix_dashed}"
   retention_in_days = 5
 
   tags = {
-    Application = "controlshift-redshift"
+    Application = "controlshift-redshift${local.namespace_suffix_dashed}"
   }
 }
 
 resource "aws_cloudwatch_log_group" "webhook" {
-  name = "/aws/lambda/controlshift-webhook-handler"
+  name = "/aws/lambda/controlshift-webhook-handler${local.namespace_suffix_dashed}"
   retention_in_days = 5
   tags = {
-    Application = "controlshift-redshift"
+    Application = "controlshift-redshift${local.namespace_suffix_dashed}"
   }
 }

--- a/processed_files_table.tf
+++ b/processed_files_table.tf
@@ -1,5 +1,5 @@
 resource "aws_dynamodb_table" "processed_files" {
-  name  = "LambdaRedshiftProcessedFiles"
+  name  = "LambdaRedshiftProcessedFiles${local.namespace_suffix_dashed}"
   billing_mode = "PROVISIONED"
   read_capacity  = 1
   write_capacity = 5

--- a/receiver.tf
+++ b/receiver.tf
@@ -6,7 +6,7 @@ data "archive_file" "receiver_zip" {
 
 resource "aws_lambda_function" "receiver_lambda" {
   filename = data.archive_file.receiver_zip.output_path
-  function_name = "controlshift-webhook-handler"
+  function_name = "controlshift-webhook-handler${local.namespace_suffix_dashed}"
   role          = aws_iam_role.receiver_lambda_role.arn
   handler       = "receiver.handler"
   runtime       = "nodejs12.x"
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "receiver_lambda" {
 }
 
 resource "aws_api_gateway_rest_api" "receiver" {
-  name = "controlshift-webhook-receiver"
+  name = "controlshift-webhook-receiver${local.namespace_suffix_dashed}"
   description = "Receives ControlShift webhooks and dumps them onto an SQS queue"
 
   endpoint_configuration {
@@ -94,17 +94,17 @@ resource "aws_api_gateway_deployment" "deployment" {
 }
 
 resource "aws_sqs_queue" "receiver_queue" {
-  name = "controlshift-received-webhooks"
+  name = "controlshift-received-webhooks${local.namespace_suffix_dashed}"
   visibility_timeout_seconds = 900
 }
 
 resource "aws_sqs_queue" "receiver_queue_glue" {
-  name = "controlshift-received-webhooks-glue"
+  name = "controlshift-received-webhooks-glue${local.namespace_suffix_dashed}"
   visibility_timeout_seconds = 900
 }
 
 # there is no formal way to associate this resource, beyond ensuring the name matches.
 resource "aws_cloudwatch_log_group" "api_gateway_log_retention" {
-  name              = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.receiver.id}/${aws_api_gateway_deployment.deployment.stage_name}"
+  name              = "API-Gateway-Execution-Logs${local.namespace_suffix_dashed}_${aws_api_gateway_rest_api.receiver.id}/${aws_api_gateway_deployment.deployment.stage_name}"
   retention_in_days = 5
 }

--- a/run_glue_crawler.tf
+++ b/run_glue_crawler.tf
@@ -7,7 +7,7 @@ data "archive_file" "run_glue_crawler_zip" {
 
 resource "aws_lambda_function" "glue_crawler_lambda" {
   filename = data.archive_file.run_glue_crawler_zip.output_path
-  function_name = "controlshift-run-glue-crawler"
+  function_name = "controlshift-run-glue-crawler${local.namespace_suffix_dashed}"
   role          = aws_iam_role.run_glue_crawler_lambda_role.arn
   handler       = "run-glue-crawler.handler"
   runtime       = "nodejs12.x"

--- a/run_glue_job.tf
+++ b/run_glue_job.tf
@@ -7,7 +7,7 @@ data "archive_file" "run_glue_job_zip" {
 
 resource "aws_lambda_function" "glue_job_lambda" {
   filename = data.archive_file.run_glue_job_zip.output_path
-  function_name = "controlshift-run-glue-job"
+  function_name = "controlshift-run-glue-job${local.namespace_suffix_dashed}"
   role          = aws_iam_role.run_glue_job_lambda_role.arn
   handler       = "run-glue-job.handler"
   runtime       = "nodejs12.x"
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "glue_job_lambda" {
 }
 
 resource "aws_cloudwatch_event_rule" "trigger_glue_job_on_crawler_finished" {
-  name        = "trigger-glue-job-on-crawler-finished"
+  name        = "trigger-glue-job-on-crawler-finished${local.namespace_suffix_dashed}"
   description = "Trigger Lambda to start Glue job when crawler finishes successfully"
 
   event_pattern = <<PATTERN
@@ -47,7 +47,7 @@ PATTERN
 
 resource "aws_cloudwatch_event_target" "trigger_run_glue_job_lambda" {
   rule      = aws_cloudwatch_event_rule.trigger_glue_job_on_crawler_finished.name
-  target_id = "trigger-controlshift-run-glue-job"
+  target_id = "trigger-controlshift-run-glue-job${local.namespace_suffix_dashed}"
   arn       = aws_lambda_function.glue_job_lambda.arn
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -122,3 +122,9 @@ variable "namespace_suffixes" {
   description = "Suffixes to add to each named resource managed by this sync. For managing multiple syncs in one AWS account."
 }
 
+variable "manage_aws_api_gateway_account_settings" {
+  default = 1
+  type = number
+  description = "Set to `0` to prevent creation of aws_api_gateway_account resource"
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -128,3 +128,9 @@ variable "manage_aws_api_gateway_account_settings" {
   description = "Set to `0` to prevent creation of aws_api_gateway_account resource"
 }
 
+variable "manage_aws_vpc_endpoint_s3" {
+  default = 1
+  type = number
+  description = "Set to `0` to prevent creation of aws_vpc_endpoint for S3"
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -115,3 +115,10 @@ variable "vpc_id" {
   type = string
   description = "The ID of the VPC Glue uses for connecting with Redshift"
 }
+
+variable "namespace_suffixes" {
+  default     = []
+  type = list(string)
+  description = "Suffixes to add to each named resource managed by this sync. For managing multiple syncs in one AWS account."
+}
+


### PR DESCRIPTION
This is the second part of https://github.com/controlshift/aws-lambda-redshift-loader/pull/1 

This commit adds a suffix to every AWS resource managed by this terraform module. Users of the module can instantiate the module multiple times, with a different suffix. Terraform will deploy resources for each sync.

Backwards compatibility: If the namespace suffix isn't specified, then there are no changes to the naming used.

I currently have this running for a client who has two syncs in their AWS account.