### PR TITLE
Migrate resources to Terraform's AWS provider v4

### DIFF
--- a/glue_job.tf
+++ b/glue_job.tf
@@ -18,14 +18,19 @@ resource "aws_glue_crawler" "signatures_crawler" {
 
 resource "aws_s3_bucket" "glue_resources" {
   bucket = var.glue_scripts_bucket_name
-  region = var.aws_region
+}
 
-  acl = "private"
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+resource "aws_s3_bucket_acl" "glue_resources" {
+  bucket = aws_s3_bucket.glue_resources.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "glue_resources" {
+  bucket = aws_s3_bucket.glue_resources.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "AES256"
     }
   }
 }
@@ -40,7 +45,7 @@ data "template_file" "signatures_script" {
   }
 }
 
-resource "aws_s3_bucket_object" "signatures_script" {
+resource "aws_s3_object" "signatures_script" {
   bucket = aws_s3_bucket.glue_resources.id
   key = "${var.controlshift_environment}/signatures_job.py"
   acl = "private"

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     aws = {
       source = "hashicorp/aws"
-      version = "~> 2.0"
+      version = "~> 4.0"
     }
     http = {
       source = "hashicorp/http"


### PR DESCRIPTION
This PR upgrades the terraform AWS provider to the latest version (v4.6) and updates the terraform resources to the new provider.
Customers using the module are expected to see the following changes:

- New `aws_s3_bucket_acl.glue_resources` resource for setting ACL on the glue scripts bucket. ACL hasn't changed, bucket is still `private`.
- New `aws_s3_bucket_acl.manifest` resource for setting ACL on the manifests bucket. ACL hasn't changed, bucket is still `private`.
- New `aws_s3_bucket_lifecycle_configuration.manifest` resource for setting the life cycle policy for files in the manifests bucket. Life cycle policy hasn't change, files will still be removed after 5 days.
- New `aws_s3_bucket_server_side_encryption_configuration.glue_resources` resource for setting server-side encryption on the glue scripts bucket.
- New `aws_s3_bucket_server_side_encryption_configuration.manifest` resource for setting server-side encryption on the manifests bucket.
- Resource `aws_s3_bucket_object.signatures_script` is replaced by `aws_s3_object.signatures_script`. This effectively creates a new file in S3 with the script run by Glue, the script itself hasn't changed though.