### PR TITLE
Use `character varying` as output type for Redshift

### DIFF
--- a/glue_job.tf
+++ b/glue_job.tf
@@ -51,8 +51,8 @@ locals {
 
   # Unsupported columnt types for Redshift: these will be replaced by the mapped type
   unsupported_output_column_types = {
-    "hstore" = "string"
-    "jsonb" = "string"
+    "hstore" = "character varying"
+    "jsonb" = "character varying"
     "numeric\\(3,2\\)" = "decimal(3,2)"
     "timestamp without time zone" = "timestamp"
   }


### PR DESCRIPTION
In Redshift, `string` is not a supported column type.  Replace `string` with `character varying` for output columns.