### PR TITLE
Update minimum required Terraform version and resolve deprecations

### DIFF
--- a/config_table.tf
+++ b/config_table.tf
@@ -13,12 +13,12 @@ resource "aws_dynamodb_table" "loader_config" {
 }
 
 resource "aws_dynamodb_table_item" "load_config_full_items" {
-  for_each = toset([for table in local.parsed_bulk_data_schemas["tables"] : table["table"]["name"]])
+  for_each = toset(local.table_names)
 
   table_name = aws_dynamodb_table.loader_config.name
   hash_key   = aws_dynamodb_table.loader_config.hash_key
 
-  item = data.template_file.loader_config_full_item[each.key].rendered
+  item = local.loader_config_full_items[each.key]
 
   lifecycle {
     ignore_changes = [
@@ -30,42 +30,16 @@ resource "aws_dynamodb_table_item" "load_config_full_items" {
 
       item
     ]
-  }
-}
-
-data "template_file" "loader_config_full_item" {
-  for_each = toset([for table in local.parsed_bulk_data_schemas["tables"] : table["table"]["name"]])
-
-  template = "${file("${path.module}/config_item.json")}"
-  vars = {
-    kind = "full"
-    bulk_data_table = each.key
-    redshift_endpoint = data.aws_redshift_cluster.sync_data_target.endpoint
-    redshift_database_name: var.redshift_database_name
-    redshift_port = data.aws_redshift_cluster.sync_data_target.port
-    redshift_username = var.redshift_username
-    redshift_password = aws_kms_ciphertext.redshift_password.ciphertext_blob
-    schema = var.redshift_schema
-    s3_bucket = "agra-data-exports-${var.controlshift_environment}"
-    manifest_bucket = aws_s3_bucket.manifest.bucket
-    manifest_prefix = var.manifest_prefix
-    failed_manifest_prefix = var.failed_manifest_prefix
-    success_topic_arn = aws_sns_topic.success_sns_topic.arn
-    failure_topic_arn = aws_sns_topic.failure_sns_topic.arn
-    current_batch = random_id.current_batch.b64_url
-    column_list = data.http.column_list[each.key].body
-    truncate_target = true
-    compress = try(local.parsed_bulk_data_schemas["settings"]["compression_format"], "")
   }
 }
 
 resource "aws_dynamodb_table_item" "load_config_incremental_items" {
-  for_each = toset([for table in local.parsed_bulk_data_schemas["tables"] : table["table"]["name"]])
+  for_each = toset(local.table_names)
 
   table_name = aws_dynamodb_table.loader_config.name
   hash_key   = aws_dynamodb_table.loader_config.hash_key
 
-  item = data.template_file.loader_config_incremental_item[each.key].rendered
+  item = local.loader_config_incremental_items[each.key]
 
   lifecycle {
     ignore_changes = [
@@ -80,29 +54,53 @@ resource "aws_dynamodb_table_item" "load_config_incremental_items" {
   }
 }
 
-data "template_file" "loader_config_incremental_item" {
-  for_each = toset([for table in local.parsed_bulk_data_schemas["tables"] : table["table"]["name"]])
+locals {
+  table_names = [for table in local.parsed_bulk_data_schemas["tables"] : table["table"]["name"]]
 
-  template = "${file("${path.module}/config_item.json")}"
-  vars = {
-    kind = "incremental"
-    bulk_data_table = each.key
-    redshift_endpoint = data.aws_redshift_cluster.sync_data_target.endpoint
-    redshift_database_name: var.redshift_database_name
-    redshift_port = data.aws_redshift_cluster.sync_data_target.port
-    redshift_username = var.redshift_username
-    redshift_password = aws_kms_ciphertext.redshift_password.ciphertext_blob
-    schema = var.redshift_schema
-    s3_bucket = "agra-data-exports-${var.controlshift_environment}"
-    manifest_bucket = aws_s3_bucket.manifest.bucket
-    manifest_prefix = var.manifest_prefix
-    failed_manifest_prefix = var.failed_manifest_prefix
-    success_topic_arn = aws_sns_topic.success_sns_topic.arn
-    failure_topic_arn = aws_sns_topic.failure_sns_topic.arn
-    current_batch = random_id.current_batch.b64_url
-    column_list = data.http.column_list[each.key].body
-    truncate_target = false
-    compress = try(local.parsed_bulk_data_schemas["settings"]["compression_format"], "")
+  loader_config_full_items = {
+    for name in local.table_names : name => templatefile("${path.module}/config_item.json", {
+      kind = "full"
+      bulk_data_table = name
+      redshift_endpoint = data.aws_redshift_cluster.sync_data_target.endpoint
+      redshift_database_name: var.redshift_database_name
+      redshift_port = data.aws_redshift_cluster.sync_data_target.port
+      redshift_username = var.redshift_username
+      redshift_password = aws_kms_ciphertext.redshift_password.ciphertext_blob
+      schema = var.redshift_schema
+      s3_bucket = "agra-data-exports-${var.controlshift_environment}"
+      manifest_bucket = aws_s3_bucket.manifest.bucket
+      manifest_prefix = var.manifest_prefix
+      failed_manifest_prefix = var.failed_manifest_prefix
+      success_topic_arn = aws_sns_topic.success_sns_topic.arn
+      failure_topic_arn = aws_sns_topic.failure_sns_topic.arn
+      current_batch = random_id.current_batch.b64_url
+      column_list = data.http.column_list[name].body
+      truncate_target = true
+      compress = try(local.parsed_bulk_data_schemas["settings"]["compression_format"], "")
+    })
+  }
+
+  loader_config_incremental_items = {
+    for name in local.table_names : name => templatefile("${path.module}/config_item.json", {
+      kind = "incremental"
+      bulk_data_table = name
+      redshift_endpoint = data.aws_redshift_cluster.sync_data_target.endpoint
+      redshift_database_name: var.redshift_database_name
+      redshift_port = data.aws_redshift_cluster.sync_data_target.port
+      redshift_username = var.redshift_username
+      redshift_password = aws_kms_ciphertext.redshift_password.ciphertext_blob
+      schema = var.redshift_schema
+      s3_bucket = "agra-data-exports-${var.controlshift_environment}"
+      manifest_bucket = aws_s3_bucket.manifest.bucket
+      manifest_prefix = var.manifest_prefix
+      failed_manifest_prefix = var.failed_manifest_prefix
+      success_topic_arn = aws_sns_topic.success_sns_topic.arn
+      failure_topic_arn = aws_sns_topic.failure_sns_topic.arn
+      current_batch = random_id.current_batch.b64_url
+      column_list = data.http.column_list[name].body
+      truncate_target = false
+      compress = try(local.parsed_bulk_data_schemas["settings"]["compression_format"], "")
+    })
   }
 }
 
@@ -134,11 +132,11 @@ data "http" "bulk_data_schemas" {
 }
 
 locals {
-  parsed_bulk_data_schemas = jsondecode(data.http.bulk_data_schemas.body)
+  parsed_bulk_data_schemas = jsondecode(data.http.bulk_data_schemas.response_body)
 }
 
 data "http" "column_list" {
-  for_each = toset([for table in local.parsed_bulk_data_schemas["tables"] : table["table"]["name"]])
+  for_each = toset(local.table_names)
 
   url = "https://${var.controlshift_hostname}/api/bulk_data/schema/columns?table=${each.key}"
 }

--- a/config_table.tf
+++ b/config_table.tf
@@ -62,7 +62,7 @@ locals {
       kind = "full"
       bulk_data_table = name
       redshift_endpoint = data.aws_redshift_cluster.sync_data_target.endpoint
-      redshift_database_name: var.redshift_database_name
+      redshift_database_name = var.redshift_database_name
       redshift_port = data.aws_redshift_cluster.sync_data_target.port
       redshift_username = var.redshift_username
       redshift_password = aws_kms_ciphertext.redshift_password.ciphertext_blob
@@ -85,7 +85,7 @@ locals {
       kind = "incremental"
       bulk_data_table = name
       redshift_endpoint = data.aws_redshift_cluster.sync_data_target.endpoint
-      redshift_database_name: var.redshift_database_name
+      redshift_database_name = var.redshift_database_name
       redshift_port = data.aws_redshift_cluster.sync_data_target.port
       redshift_username = var.redshift_username
       redshift_password = aws_kms_ciphertext.redshift_password.ciphertext_blob

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.4.5"
   required_providers {
     archive = {
       source = "hashicorp/archive"
@@ -13,9 +13,6 @@ terraform {
     }
     random = {
       source = "hashicorp/random"
-    }
-    template = {
-      source = "hashicorp/template"
     }
   }
 }


### PR DESCRIPTION
The lambdas in this repo are using Node.js 16.x, which [AWS has deprecated](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-deprecated) (updates will no longer be allowed after July 1, 2026).

However, in order to support a newer version of Node, the AWS provider in this Terraform module needs to be updated (to `"~> 5.26.0"`).

However, in order to update the AWS provider version, we need to use a newer version of Terraform (1.4.5).

However, this version doesn't support the deprecated `hashicorp/template` provider on non-Intel Macs, which makes deploying from newer Mac laptops difficult. See discussions of this issue [here](https://github.com/hashicorp/terraform/issues/33388) and [here](https://github.com/hashicorp/terraform-provider-template/issues/85).

This PR updates Terraform to version 1.4.5 and resolves the deprecation notices by removing the dependency on the old `template_file` provider, as well updating some of the S3 configuration. The AWS provider version is NOT updated here, because that also requires updating the js code for the lambdas due to AWS requiring the use of their newer SDK.

When deploying https://github.com/controlshift/bulk-data-example:
- Back up your Terraform tfstate file.
- `terraform init` will complain about references to the old "template" provider. To resolve this:
  - Delete your .terraform/ directory and .terraform.lock.hcl file.
  - Remove old template provider references from the state file. `terraform state rm $(terraform state list | grep template)`
- Now run `terraform init`
- Import existing infrastructure (with `GLUE_SCRIPTS_BUCKET_NAME` replaced with the actual S3 bucket names): `terraform import module.terraform-aws-controlshift-redshift-sync.aws_s3_bucket_lifecycle_configuration.glue_resources GLUE_SCRIPTS_BUCKET_NAME`
- `terraform plan`
- `terraform apply`
